### PR TITLE
fix locale settings labels

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -1,8 +1,8 @@
 [mod-setting-name]
-sil-filcmb-empty-slots=Empty Filter slots
+sfc-empty-slots=Empty Filter slots
 
 [mod-setting-description]
-sil-filcmb-empty-slots=Number of empty slots in Filter Combinators when opening the UI. Increasing this value to large values might cause lag.
+sfc-empty-slots=Number of empty slots in Filter Combinators when opening the UI. Increasing this value to large values might cause lag.
 
 [shortcut-name]
 


### PR DESCRIPTION
The locale labels for the settings menu are not correct, so it shows up as labels (not localized). This fixes it for me.