### PR TITLE
Factorio 2.0 Updates

### DIFF
--- a/migrations/0.1.0.lua
+++ b/migrations/0.1.0.lua
@@ -4,7 +4,7 @@
 
 for _, f in pairs(game.forces) do
     f.recipes['sil-filter-combinator'].enabled = f.technologies['circuit-network'].researched
-    if game.active_mods['nullius'] then
-        f.recipes['sil-filter-combinator'].enabled = f.technologies['nullius-computation'].researched
+    if f.technologies['circuit-network'] and f.technologies['circuit-network'].researched then
+        f.recipes['sil-filter-combinator'].enabled = true
     end
 end

--- a/migrations/1.0.0.lua
+++ b/migrations/1.0.0.lua
@@ -4,6 +4,11 @@
 
 require('__core__/lualib/util.lua')
 
+global = global or {}
+global.sil_fc_data = global.sil_fc_data or {}
+global.sil_filter_combinators = global.sil_filter_combinators or {}
+global.sil_fc_migration_data = global.sil_fc_migration_data or {}
+
 local name_prefix = 'sil-filter-combinator'
 local name_prefix_len = #name_prefix
 local local_data = table.deepcopy(global.sil_fc_data)


### PR DESCRIPTION
Minor changes in Migrations/0.1.0.lua and 1.0.0.lua to allow proper support for Factorio 2.0 as of 10/26/2024

0.1.0.lua had a missing key error with the API updates
1.0.0 had a nil error on global with the API updates

I will publish this mod as a fix if required, but shall keep original authors name and copyright as included.